### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # easeui
-####EaseUI是一个基于环信sdk的UI库，封装了IM功能常用的控件、fragment等等。此项目包含一个简单使用的demo：simpledemo，开发者可导出查看。
-####github上的代码不包含环信sdk，clone使用时需要把环信sdk所需的jar包，so等等拷贝进来。
+#### EaseUI是一个基于环信sdk的UI库，封装了IM功能常用的控件、fragment等等。此项目包含一个简单使用的demo：simpledemo，开发者可导出查看。
+#### github上的代码不包含环信sdk，clone使用时需要把环信sdk所需的jar包，so等等拷贝进来。
 
 > easeui文档地址：http://docs.easemob.com/doku.php?id=start:200androidcleintintegration:135easeuiuseguide


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
