### PR TITLE
修复一个搜索bug

### DIFF
--- a/src/com/easemob/easeui/adapter/EaseContactAdapter.java
+++ b/src/com/easemob/easeui/adapter/EaseContactAdapter.java
@@ -207,6 +207,10 @@ public class EaseContactAdapter extends ArrayAdapter<EaseUser> implements Sectio
 			EMLog.d(TAG, "contacts original size: " + mOriginalList.size());
 			EMLog.d(TAG, "contacts copy size: " + copyUserList.size());
 
+			if (copyUserList.size() > mOriginalList.size()) {
+                		mOriginalList = copyUserList;
+            		}
+			
 			if (prefix == null || prefix.length() == 0) {
 				results.values = copyUserList;
 				results.count = copyUserList.size();

--- a/src/com/easemob/easeui/adapter/EaseConversationAdapater.java
+++ b/src/com/easemob/easeui/adapter/EaseConversationAdapater.java
@@ -263,6 +263,11 @@ public class EaseConversationAdapater extends ArrayAdapter<EMConversation> {
 				results.values = copyConversationList;
 				results.count = copyConversationList.size();
 			} else {
+				
+				if (copyConversationList.size() > mOriginalValues.size()) {
+                    			mOriginalValues = copyConversationList;
+                		}
+				
 				String prefixString = prefix.toString();
 				final int count = mOriginalValues.size();
 				final ArrayList<EMConversation> newValues = new ArrayList<EMConversation>();


### PR DESCRIPTION
联系人列表搜索不到结果后删除一个文字后不能匹配的bug，例如输入17匹配到好友171，输入172后没有结果，删除2后变成17依然没有结果的bug

同样的问题出现在好友列表中。